### PR TITLE
Desktop screens fit a window shorter than they were designed for

### DIFF
--- a/lib/desktop/common/dialog/d_content_dialog.dart
+++ b/lib/desktop/common/dialog/d_content_dialog.dart
@@ -35,35 +35,51 @@ class DContentDialog extends ConsumerWidget {
       child: Container(
         constraints: constraints,
         decoration: style.decoration,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Padding(
-              padding: style.padding ?? EdgeInsets.zero,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  if (title != null)
-                    Padding(
-                      padding: style.titlePadding ?? EdgeInsets.zero,
-                      child: DefaultTextStyle(
-                        style: style.titleStyle ?? const TextStyle(),
-                        child: title!,
-                      ),
+        child: LayoutBuilder(
+          builder: (context, box) {
+            // When the dialog's height is bounded (a window shorter than the
+            // dialog was designed for), the shortfall is handed to the
+            // content, which can then shrink or scroll, instead of the dialog
+            // overflowing. The loose fit keeps every dialog at its natural
+            // size where there is room.
+            Widget shrinkable(Widget child) => box.hasBoundedHeight
+                ? Flexible(fit: FlexFit.loose, child: child)
+                : child;
+
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                shrinkable(
+                  Padding(
+                    padding: style.padding ?? EdgeInsets.zero,
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        if (title != null)
+                          Padding(
+                            padding: style.titlePadding ?? EdgeInsets.zero,
+                            child: DefaultTextStyle(
+                              style: style.titleStyle ?? const TextStyle(),
+                              child: title!,
+                            ),
+                          ),
+                        if (content != null)
+                          shrinkable(
+                            Padding(
+                              padding: style.bodyPadding ?? EdgeInsets.zero,
+                              child: DefaultTextStyle(
+                                style: style.bodyStyle ?? const TextStyle(),
+                                child: content!,
+                              ),
+                            ),
+                          ),
+                      ],
                     ),
-                  if (content != null)
-                    Padding(
-                      padding: style.bodyPadding ?? EdgeInsets.zero,
-                      child: DefaultTextStyle(
-                        style: style.bodyStyle ?? const TextStyle(),
-                        child: content!,
-                      ),
-                    ),
-                ],
-              ),
-            ),
-            if (actions != null)
+                  ),
+                ),
+                if (actions != null)
               Container(
                 decoration: style.actionsDecoration,
                 padding: style.actionsPadding,
@@ -95,7 +111,9 @@ class DContentDialog extends ConsumerWidget {
                   }(),
                 ),
               ),
-          ],
+              ],
+            );
+          },
         ),
       ),
     );

--- a/lib/desktop/instant_swap/d_instant_swap.dart
+++ b/lib/desktop/instant_swap/d_instant_swap.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:sideswap/common/sideswap_colors.dart';
+import 'package:sideswap/desktop/widgets/d_scroll_when_short.dart';
 import 'package:sideswap/screens/instant_swap/instant_swap.dart';
 
 class DInstantSwap extends StatelessWidget {
@@ -13,14 +14,16 @@ class DInstantSwap extends StatelessWidget {
         Column(
           children: [
             const SizedBox(height: 28),
-            Container(
-              width: 570,
-              height: 561,
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(8),
-                color: SideSwapColors.prussianBlue,
+            Flexible(
+              child: Container(
+                width: 570,
+                clipBehavior: Clip.antiAlias,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(8),
+                  color: SideSwapColors.prussianBlue,
+                ),
+                child: DScrollWhenShort(height: 561, child: InstantSwap()),
               ),
-              child: InstantSwap(),
             ),
           ],
         ),

--- a/lib/desktop/main/d_select_inputs_popup.dart
+++ b/lib/desktop/main/d_select_inputs_popup.dart
@@ -43,8 +43,10 @@ class DSelectInputsPopup extends HookConsumerWidget {
           Navigator.of(context).pop();
         },
       ),
-      content: SizedBox(
-        height: 712,
+      content: ConstrainedBox(
+        // Design height; the inputs list is flexible and absorbs a shorter
+        // window.
+        constraints: const BoxConstraints(maxHeight: 712),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/lib/desktop/markets/widgets/market_order_panel.dart
+++ b/lib/desktop/markets/widgets/market_order_panel.dart
@@ -266,22 +266,29 @@ class MarketOrderPanel extends HookConsumerWidget {
             },
           ),
           Flexible(
-            child: Column(
-              children: [
-                MarketTypeSwitch(),
-                Consumer(
-                  builder: (context, ref, child) {
-                    final marketTypeSwitchState = ref.watch(
-                      marketTypeSwitchStateProvider,
-                    );
+            // The order form is a fixed-height design; on a window shorter
+            // than it was laid out for it scrolls instead of overflowing the
+            // panel.
+            child: SingleChildScrollView(
+              primary: false,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  MarketTypeSwitch(),
+                  Consumer(
+                    builder: (context, ref, child) {
+                      final marketTypeSwitchState = ref.watch(
+                        marketTypeSwitchStateProvider,
+                      );
 
-                    return switch (marketTypeSwitchState) {
-                      MarketTypeSwitchStateMarket() => MarketPanel(),
-                      _ => LimitPanel(),
-                    };
-                  },
-                ),
-              ],
+                      return switch (marketTypeSwitchState) {
+                        MarketTypeSwitchStateMarket() => MarketPanel(),
+                        _ => LimitPanel(),
+                      };
+                    },
+                  ),
+                ],
+              ),
             ),
           ),
         ],

--- a/lib/desktop/widgets/d_popup_with_close.dart
+++ b/lib/desktop/widgets/d_popup_with_close.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:sideswap/common/sideswap_colors.dart';
 import 'package:sideswap/desktop/common/button/d_icon_button.dart';
+import 'package:sideswap/desktop/widgets/d_scroll_when_short.dart';
 
 part 'd_popup_with_close.freezed.dart';
 
@@ -71,43 +72,52 @@ class DPopupWithCloseContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final closeButton = DIconButton(
+      icon: const Icon(Icons.close, color: SideSwapColors.freshAir, size: 18),
+      onPressed: switch (onClose) {
+        final onClose? => onClose,
+        _ => () {
+          Navigator.pop(context);
+        },
+      },
+    );
+
     return Center(
       child: Material(
         borderRadius: BorderRadius.circular(8),
         child: Container(
           width: width,
-          height: height,
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(8),
             color: SideSwapColors.blumine,
           ),
           child: ClipRRect(
             borderRadius: BorderRadius.circular(8),
-            child: Stack(
-              alignment: alignment,
-              children: [
-                child,
-                Align(
-                  alignment: Alignment.topRight,
-                  child: Padding(
-                    padding: const EdgeInsets.all(20),
-                    child: DIconButton(
-                      icon: const Icon(
-                        Icons.close,
-                        color: SideSwapColors.freshAir,
-                        size: 18,
-                      ),
-                      onPressed: switch (onClose) {
-                        final onClose? => onClose,
-                        _ => () {
-                          Navigator.pop(context);
-                        },
-                      },
+            child: switch (height) {
+              // A popup with a design height is laid out at that height and
+              // scrolls when the window is shorter, instead of clipping its
+              // bottom. The close button stays in the popup's corner.
+              final height? => Stack(
+                alignment: alignment,
+                children: [
+                  DScrollWhenShort(height: height, child: child),
+                  Positioned(top: 20, right: 20, child: closeButton),
+                ],
+              ),
+              _ => Stack(
+                alignment: alignment,
+                children: [
+                  child,
+                  Align(
+                    alignment: Alignment.topRight,
+                    child: Padding(
+                      padding: const EdgeInsets.all(20),
+                      child: closeButton,
                     ),
                   ),
-                ),
-              ],
-            ),
+                ],
+              ),
+            },
           ),
         ),
       ),

--- a/lib/desktop/widgets/d_scroll_when_short.dart
+++ b/lib/desktop/widgets/d_scroll_when_short.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/widgets.dart';
+
+/// Lays [child] out at [height], the height it was designed for, and scrolls
+/// it when the parent is shorter. A parent at least [height] tall gets a
+/// plain [height]-tall box with nothing to scroll, so screens designed for
+/// the default window keep their layout there and become scrollable on a
+/// laptop whose work area is smaller.
+///
+/// The tree has the same shape whether or not it scrolls, so a window resized
+/// across the design height keeps the child's state (form fields, focus,
+/// navigation) instead of re-inflating it.
+class DScrollWhenShort extends StatelessWidget {
+  const DScrollWhenShort({
+    super.key,
+    required this.height,
+    required this.child,
+  });
+
+  final double height;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      primary: false,
+      child: SizedBox(height: height, child: child),
+    );
+  }
+}

--- a/lib/screens/pegs/d_peg_in_out.dart
+++ b/lib/screens/pegs/d_peg_in_out.dart
@@ -19,6 +19,7 @@ import 'package:sideswap/screens/swap/widgets/swap_deliver_amount.dart';
 import 'package:sideswap/screens/swap/widgets/swap_middle_icon.dart';
 import 'package:sideswap/screens/swap/widgets/swap_receive_amount.dart';
 import 'package:sideswap/screens/tx/widgets/empty_tx_list_item.dart';
+import 'package:sideswap/desktop/widgets/d_scroll_when_short.dart';
 import 'package:sideswap_protobuf/sideswap_api.dart';
 
 class DPegInOut extends HookConsumerWidget {
@@ -44,23 +45,26 @@ class DPegInOut extends HookConsumerWidget {
           children: [
             Container(
               width: 570,
-              height: 680,
+              clipBehavior: Clip.antiAlias,
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(8),
                 color: SideSwapColors.prussianBlue,
               ),
-              child: Column(
-                children: [
-                  const SizedBox(height: 18),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 35),
-                    child: TopPegButtons(),
-                  ),
-                  const SizedBox(height: 24),
-                  swapType == SwapType.pegIn()
-                      ? Flexible(child: const DPegIn())
-                      : Flexible(child: const DPegOut()),
-                ],
+              child: DScrollWhenShort(
+                height: 680,
+                child: Column(
+                  children: [
+                    const SizedBox(height: 18),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 35),
+                      child: TopPegButtons(),
+                    ),
+                    const SizedBox(height: 24),
+                    swapType == SwapType.pegIn()
+                        ? Flexible(child: const DPegIn())
+                        : Flexible(child: const DPegOut()),
+                  ],
+                ),
               ),
             ),
           ],

--- a/test/desktop/common/dialog/d_content_dialog_test.dart
+++ b/test/desktop/common/dialog/d_content_dialog_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sideswap/desktop/common/dialog/d_content_dialog.dart';
+
+const contentKey = Key('content');
+
+void main() {
+  // DContentDialogThemeData.standard() reads the theme through a throwaway
+  // ProviderContainer whose dispose timer never settles under fake async, so
+  // the pump runs inside `runAsync` (prior art: test/widgets/d_settings_test.dart).
+  Future<void> pump(
+    WidgetTester tester, {
+    required Size view,
+    required double contentHeight,
+    Widget Function(Widget dialog)? wrap,
+  }) => tester.runAsync(() async {
+    tester.view.physicalSize = view;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    final dialog = DContentDialog(
+      constraints: const BoxConstraints(maxWidth: 1040, maxHeight: 808),
+      title: const Text('Title'),
+      content: SizedBox(key: contentKey, height: contentHeight),
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(home: wrap == null ? dialog : wrap(dialog)),
+      ),
+    );
+  });
+
+  // The dialog's own render object is its Align, which fills the window; the
+  // decorated box inside it is the dialog the user sees.
+  Size dialogSize(WidgetTester tester) => tester.getSize(
+    find
+        .descendant(
+          of: find.byType(DContentDialog),
+          matching: find.byType(Container),
+        )
+        .first,
+  );
+
+  testWidgets('a dialog that fits keeps its natural size', (tester) async {
+    await pump(tester, view: const Size(1264, 648), contentHeight: 100);
+
+    expect(tester.getSize(find.byKey(contentKey)).height, 100);
+    expect(dialogSize(tester).height, lessThan(300));
+  });
+
+  testWidgets('a dialog designed taller than the window is bounded to the '
+      'window, with the shortfall taken from the content', (tester) async {
+    await pump(tester, view: const Size(1264, 648), contentHeight: 712);
+
+    expect(dialogSize(tester).height, lessThanOrEqualTo(648));
+    final content = tester.getSize(find.byKey(contentKey)).height;
+    expect(content, lessThan(712));
+    expect(content, greaterThan(500));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('a dialog with room takes its design height', (tester) async {
+    await pump(tester, view: const Size(1600, 1000), contentHeight: 712);
+
+    expect(tester.getSize(find.byKey(contentKey)).height, 712);
+  });
+
+  testWidgets('where nothing bounds the height the dialog stays '
+      'content-sized', (tester) async {
+    await pump(
+      tester,
+      view: const Size(1264, 648),
+      contentHeight: 100,
+      wrap: (dialog) => SingleChildScrollView(child: dialog),
+    );
+
+    expect(tester.getSize(find.byKey(contentKey)).height, 100);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/desktop/widgets/d_popup_with_close_test.dart
+++ b/test/desktop/widgets/d_popup_with_close_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sideswap/desktop/common/button/d_icon_button.dart';
+import 'package:sideswap/desktop/widgets/d_popup_with_close.dart';
+import 'package:sideswap/desktop/widgets/d_scroll_when_short.dart';
+
+const popupWidth = 580.0;
+const popupHeight = 710.0;
+const childKey = Key('child');
+
+void main() {
+  // DIconButton resolves its theme through a throwaway ProviderContainer whose
+  // dispose timer never settles under fake async, so the pump runs inside
+  // `runAsync` (prior art: test/widgets/d_settings_test.dart).
+  Future<void> pump(
+    WidgetTester tester, {
+    required Size view,
+    double? height = popupHeight,
+    Widget child = const SizedBox.expand(key: childKey),
+  }) => tester.runAsync(() async {
+    tester.view.physicalSize = view;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: DPopupWithCloseContent(
+            width: popupWidth,
+            height: height,
+            child: child,
+          ),
+        ),
+      ),
+    );
+  });
+
+  Rect popupRect(WidgetTester tester) =>
+      tester.getRect(find.byType(DScrollWhenShort));
+
+  testWidgets('a window with room shows the popup at its design height', (
+    tester,
+  ) async {
+    await pump(tester, view: const Size(1600, 1000));
+
+    expect(popupRect(tester).size, const Size(popupWidth, popupHeight));
+    expect(tester.getSize(find.byKey(childKey)).height, popupHeight);
+  });
+
+  testWidgets('a shorter window gets a popup that fills it and scrolls, '
+      'with the close button still in the corner', (tester) async {
+    // 1920x1080 @ 150 % laptop: 1280x720 logical, 648 px client height.
+    await pump(tester, view: const Size(1264, 648));
+
+    final popup = popupRect(tester);
+    expect(popup.size, const Size(popupWidth, 648));
+    // The content keeps its design layout...
+    expect(tester.getSize(find.byKey(childKey)).height, popupHeight);
+    // ...and the shortfall is scrollable rather than clipped.
+    final position = tester
+        .state<ScrollableState>(find.byType(Scrollable))
+        .position;
+    expect(position.maxScrollExtent, popupHeight - 648);
+
+    final close = tester.getRect(find.byType(DIconButton));
+    expect(close.top, popup.top + 20);
+    expect(close.right, popup.right - 20);
+  });
+
+  testWidgets('a popup without a design height is left as it was: no scroll '
+      'wrapper', (tester) async {
+    await pump(
+      tester,
+      view: const Size(1600, 1000),
+      height: null,
+      child: const SizedBox(key: childKey, width: 200, height: 300),
+    );
+
+    expect(find.byType(DScrollWhenShort), findsNothing);
+    expect(tester.getSize(find.byKey(childKey)), const Size(200, 300));
+    expect(find.byType(DIconButton), findsOneWidget);
+  });
+}

--- a/test/desktop/widgets/d_scroll_when_short_test.dart
+++ b/test/desktop/widgets/d_scroll_when_short_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sideswap/desktop/widgets/d_scroll_when_short.dart';
+
+const designHeight = 700.0;
+const childKey = Key('child');
+
+/// A child whose state must survive the parent crossing the design height.
+class _Counter extends StatefulWidget {
+  const _Counter();
+
+  @override
+  State<_Counter> createState() => _CounterState();
+}
+
+class _CounterState extends State<_Counter> {
+  int taps = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => setState(() => taps++),
+      child: SizedBox.expand(key: childKey),
+    );
+  }
+}
+
+void main() {
+  // The default 800x600 test view would clamp the tall parents used below.
+  void sizeView(WidgetTester tester) {
+    tester.view.physicalSize = const Size(2000, 1200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+  }
+
+  Future<void> pump(
+    WidgetTester tester,
+    Size parent, {
+    Widget child = const SizedBox.expand(key: childKey),
+  }) {
+    sizeView(tester);
+    return tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          // Loose constraints, as from the Center / Row / Container parents
+          // the widget is used under.
+          child: Center(
+            child: ConstrainedBox(
+              constraints: BoxConstraints.loose(parent),
+              child: DScrollWhenShort(height: designHeight, child: child),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  double maxScrollExtent(WidgetTester tester) => tester
+      .state<ScrollableState>(find.byType(Scrollable))
+      .position
+      .maxScrollExtent;
+
+  testWidgets('lays the child out at the design height when there is room, '
+      'with nothing to scroll', (tester) async {
+    await pump(tester, const Size(800, 1000));
+
+    expect(tester.getSize(find.byKey(childKey)).height, designHeight);
+    expect(tester.getSize(find.byType(DScrollWhenShort)).height, designHeight);
+    expect(maxScrollExtent(tester), 0);
+  });
+
+  testWidgets('fills a shorter parent and scrolls the difference', (
+    tester,
+  ) async {
+    await pump(tester, const Size(800, 500));
+
+    expect(tester.getSize(find.byType(DScrollWhenShort)).height, 500);
+    expect(tester.getSize(find.byKey(childKey)).height, designHeight);
+    expect(maxScrollExtent(tester), designHeight - 500);
+  });
+
+  testWidgets('takes the design height where the parent height is unbounded', (
+    tester,
+  ) async {
+    sizeView(tester);
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Column(
+            children: const [
+              DScrollWhenShort(
+                height: designHeight,
+                child: SizedBox.expand(key: childKey),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(childKey)).height, designHeight);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('keeps the child state when the parent crosses the design '
+      'height', (tester) async {
+    await pump(tester, const Size(800, 1000), child: const _Counter());
+    await tester.tap(find.byKey(childKey));
+    await tester.pump();
+    final state = tester.state<_CounterState>(find.byType(_Counter));
+    expect(state.taps, 1);
+
+    await pump(tester, const Size(800, 500), child: const _Counter());
+    expect(tester.state<_CounterState>(find.byType(_Counter)), same(state));
+    expect(state.taps, 1);
+
+    await pump(tester, const Size(800, 1000), child: const _Counter());
+    expect(tester.state<_CounterState>(find.byType(_Counter)), same(state));
+    expect(state.taps, 1);
+  });
+}


### PR DESCRIPTION
Reworked after @malcolmpl's review (thanks, it was right on every point). The window-sizing half is now #79. This PR is the other half: the desktop screens themselves, redesigned as he recommended rather than patched. The `FittedBox`, its `MediaQuery` rewrite, the design constant and the seven overlay-anchor problems are gone, because there is no render transform any more.

**Approach.** The pattern already in `lib/desktop/settings/d_settings.dart`: fixed-height content scrolls when the window is short and is left exactly as designed otherwise. Where content is already flexible it is simply given the room to shrink.

**Shared widgets**

- `DScrollWhenShort(height, child)` (new, `lib/desktop/widgets/`): lays the child out at its design height and scrolls it when the parent is shorter. The tree has the same shape either way, so resizing across the design height keeps the child's state; a test asserts the `State` instance survives.
- `DPopupWithClose`: a popup with a `height` is laid out at that height through `DScrollWhenShort`; the close button is `Positioned` in the corner instead of an expanding `Align`. Popups without a height are untouched. Covers the 14 fixed-height popups (send 710/675, select asset 710, asset info 632, tx popups 660, ...) in one place.
- `DContentDialog`: when the dialog's height is bounded, the title/content column and the content are wrapped in loose `Flexible`s, so a dialog taller than the window hands the shortfall to its content instead of overflowing. Loose fit means content-sized dialogs keep their natural size (the existing settings/descriptor widget tests pass unchanged). Guarded by `hasBoundedHeight`, so a dialog in an unbounded parent is laid out as before.

**Per-screen**

| Screen | Before | Now |
| --- | --- | --- |
| `d_select_inputs_popup.dart` | content `SizedBox(height: 712)` | `maxHeight: 712`; the inputs list is already `Flexible` and absorbs the rest |
| `d_peg_in_out.dart` | `Container` 570x680 | 570 wide, `DScrollWhenShort(680)` |
| `d_instant_swap.dart` | `Container` 570x561 in a non-flex `Column` | `Flexible` + `DScrollWhenShort(561)` |
| `market_order_panel.dart` | order form (`MarketPanel`/`LimitPanel`, 331 px boxes) in a `Flexible(Column)` that overflowed | the form scrolls inside the panel |
| `d_tx_and_orders_panel.dart` | `minHeight: 227`, `height: 186` | unchanged: on Home the assets panel above it is `Flexible`, on Markets the order panel above is now the thing that gives |

`DPopupWithClose` and `DContentDialog` changes cover `d_payment_select_asset.dart` and `d_send_popup.dart` from the review table without touching them.

**Tests.** 11 widget tests, `test/desktop/`: `DScrollWhenShort` (room / short / unbounded parent / state survives resize), `DPopupWithCloseContent` (design height, 1264x648 laptop client with close button still in the corner and the shortfall scrollable, no-height passthrough), `DContentDialog` (natural size, bounded to a short window, room, unbounded parent). Full suite: 3639 passed under `--test-randomize-ordering-seed=random`. `flutter analyze` clean on all changed files.

**Not verified on a device.** I have no laptop display here. The per-screen wiring (peg, instant swap, select inputs, markets) is provider-heavy and is covered through the shared widgets' tests, not screen tests. The manual check `docs/TESTING.md` asks for is the 1920x1080 @150 % and 1366x768 @100 % cases on Windows: every page and popup reachable, nothing clipped, scrollbars only where the window is short.

**Pre-existing, noted while here (not changed):** a `DPopupWithClose` without a `height` fills the available height because its close-button `Align` expands; only the three empty-notification fallbacks use that form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)