### PR TITLE
Desktop window opens within the screen's work area

### DIFF
--- a/lib/desktop/desktop_window_size.dart
+++ b/lib/desktop/desktop_window_size.dart
@@ -1,0 +1,61 @@
+import 'dart:math' as math;
+import 'dart:ui';
+
+import 'package:window_size/window_size.dart' show Screen;
+
+/// The outer window the desktop screens are laid out for, in logical pixels
+/// (window_manager sizes the outer window). The client area is 16 px
+/// narrower and 40 px shorter once Windows takes its frame.
+const desktopWindowSize = Size(1088, 880);
+
+/// The screen's work area (the screen minus taskbar, dock or menu bar) in
+/// logical pixels, or null when it cannot be determined.
+///
+/// window_size reports the Windows work area in physical pixels with the
+/// DPI scale alongside, while window_manager wants logical pixels; the other
+/// desktops already report logical units. Pass [workAreaIsPhysical] for the
+/// platforms that need the conversion. An unusable scale factor makes the
+/// answer unknown rather than passing a physical size off as logical, which
+/// would open a window larger than the screen on a scaled display.
+Size? logicalWorkArea(Screen screen, {required bool workAreaIsPhysical}) {
+  final frame = screen.frame.size;
+  final visible = screen.visibleFrame.size;
+  if (!_isUsable(frame) || !_isUsable(visible)) {
+    return null;
+  }
+
+  // The work area is part of the screen; never trust a report beyond it.
+  final area = Size(
+    math.min(visible.width, frame.width),
+    math.min(visible.height, frame.height),
+  );
+
+  if (!workAreaIsPhysical) {
+    return area;
+  }
+
+  final scale = screen.scaleFactor;
+  if (!scale.isFinite || scale <= 0) {
+    return null;
+  }
+  return area / scale;
+}
+
+/// The outer window size to open on a screen whose work area is [workArea]
+/// logical pixels: [desktopWindowSize], shrunk on each axis that would not
+/// fit. An unknown (null) work area keeps the default.
+Size desktopWindowSizeFor(Size? workArea) {
+  if (workArea == null || !_isUsable(workArea)) {
+    return desktopWindowSize;
+  }
+  return Size(
+    math.min(desktopWindowSize.width, workArea.width),
+    math.min(desktopWindowSize.height, workArea.height),
+  );
+}
+
+bool _isUsable(Size size) =>
+    size.width.isFinite &&
+    size.height.isFinite &&
+    size.width > 0 &&
+    size.height > 0;

--- a/lib/start_app.dart
+++ b/lib/start_app.dart
@@ -13,6 +13,7 @@ import 'package:sideswap/common/utils/build_config.dart';
 import 'package:sideswap/common/utils/sideswap_logger.dart';
 import 'package:sideswap/desktop/common/windows_registry.dart';
 import 'package:sideswap/desktop/desktop_app_main.dart';
+import 'package:sideswap/desktop/desktop_window_size.dart';
 import 'package:sideswap/providers/config_provider.dart';
 import 'package:sideswap/screens/flavor_config.dart';
 import 'package:args/args.dart';
@@ -89,16 +90,28 @@ Future<void> startApp(List<String> args, {bool isFdroid = false}) async {
       });
     }
   } else {
-    // min app width is 1072 (for some reason 16px is cutted o_O)
-    appScreenSize = const Size(1088, 880);
+    // The screens are laid out for this window. On a screen whose work area
+    // (screen minus taskbar) is smaller, the window opens to fit the work
+    // area instead of ending up under the taskbar.
+    appScreenSize = desktopWindowSize;
 
-    // workaround for potato laptop resolution 1366x768
     final currentScreen = await window_size.getCurrentScreen();
-    if (currentScreen != null) {
-      if (currentScreen.frame.size.height < 880) {
-        // a bit lower app height - we don't want to reduce it more
-        appScreenSize = const Size(1088, 768);
+    if (currentScreen == null) {
+      logger.w('Current screen unknown, opening at $desktopWindowSize');
+    } else {
+      final workArea = logicalWorkArea(
+        currentScreen,
+        workAreaIsPhysical: Platform.isWindows,
+      );
+      if (workArea == null) {
+        logger.w(
+          'Unusable screen report '
+          '(frame ${currentScreen.frame}, visible ${currentScreen.visibleFrame}, '
+          'scale ${currentScreen.scaleFactor}), opening at $desktopWindowSize',
+        );
       }
+      appScreenSize = desktopWindowSizeFor(workArea);
+      logger.i('Work area $workArea, window $appScreenSize');
     }
 
     final windowOptions = WindowOptions(

--- a/test/desktop/desktop_window_size_test.dart
+++ b/test/desktop/desktop_window_size_test.dart
@@ -1,0 +1,126 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sideswap/desktop/desktop_window_size.dart';
+import 'package:window_size/window_size.dart' show Screen;
+
+Screen screen({
+  required Size frame,
+  required Size visible,
+  double scale = 1.0,
+}) => Screen(
+  Rect.fromLTWH(0, 0, frame.width, frame.height),
+  Rect.fromLTWH(0, 0, visible.width, visible.height),
+  scale,
+);
+
+void main() {
+  group('logicalWorkArea', () {
+    test('is the visible frame where the plugin reports logical units', () {
+      // macOS: points, menu bar and dock already taken off.
+      final s = screen(
+        frame: const Size(1440, 900),
+        visible: const Size(1440, 815),
+        scale: 2.0,
+      );
+      expect(
+        logicalWorkArea(s, workAreaIsPhysical: false),
+        const Size(1440, 815),
+      );
+    });
+
+    test('divides a physical work area by the scale factor', () {
+      // Windows 1920x1080 @ 150 %, 48 px taskbar.
+      final s = screen(
+        frame: const Size(1920, 1080),
+        visible: const Size(1920, 1032),
+        scale: 1.5,
+      );
+      expect(
+        logicalWorkArea(s, workAreaIsPhysical: true),
+        const Size(1280, 688),
+      );
+    });
+
+    test('is unknown rather than physical when the scale is unusable', () {
+      for (final scale in [0.0, -1.0, double.nan, double.infinity]) {
+        final s = screen(
+          frame: const Size(1920, 1080),
+          visible: const Size(1920, 1032),
+          scale: scale,
+        );
+        expect(logicalWorkArea(s, workAreaIsPhysical: true), isNull);
+        // The same report is fine where no conversion is needed.
+        expect(
+          logicalWorkArea(s, workAreaIsPhysical: false),
+          const Size(1920, 1032),
+        );
+      }
+    });
+
+    test('never exceeds the screen frame', () {
+      final s = screen(
+        frame: const Size(1366, 768),
+        visible: const Size(1400, 800),
+      );
+      expect(
+        logicalWorkArea(s, workAreaIsPhysical: false),
+        const Size(1366, 768),
+      );
+    });
+
+    test('is unknown for an unusable frame or visible frame', () {
+      expect(
+        logicalWorkArea(
+          screen(frame: Size.zero, visible: const Size(1366, 728)),
+          workAreaIsPhysical: false,
+        ),
+        isNull,
+      );
+      expect(
+        logicalWorkArea(
+          screen(frame: const Size(1366, 768), visible: Size.zero),
+          workAreaIsPhysical: false,
+        ),
+        isNull,
+      );
+      expect(
+        logicalWorkArea(
+          screen(
+            frame: const Size(1366, 768),
+            visible: const Size(double.infinity, 728),
+          ),
+          workAreaIsPhysical: false,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('desktopWindowSizeFor', () {
+    test('keeps the default when the work area is large enough', () {
+      expect(desktopWindowSizeFor(const Size(2560, 1400)), desktopWindowSize);
+      expect(desktopWindowSizeFor(desktopWindowSize), desktopWindowSize);
+    });
+
+    test('shrinks each axis to the work area', () {
+      // 1920x1080 @ 150 % laptop: 1280x688 logical.
+      expect(desktopWindowSizeFor(const Size(1280, 688)), const Size(1088, 688));
+      // 1366x768 @ 100 % with a 40 px taskbar.
+      expect(desktopWindowSizeFor(const Size(1366, 728)), const Size(1088, 728));
+      expect(
+        desktopWindowSizeFor(const Size(1000, 1000)),
+        const Size(1000, 880),
+      );
+    });
+
+    test('keeps the default for an unknown or unusable work area', () {
+      expect(desktopWindowSizeFor(null), desktopWindowSize);
+      expect(desktopWindowSizeFor(Size.zero), desktopWindowSize);
+      expect(
+        desktopWindowSizeFor(const Size(double.infinity, 700)),
+        desktopWindowSize,
+      );
+    });
+  });
+}


### PR DESCRIPTION
The sizing half of #78, split out as @malcolmpl recommended in his review.

On laptops the desktop window did not fit the screen: the bottom nav ended up under the taskbar. Two distinct causes on `master`:

- the window asked for 1088x880 regardless of the screen;
- the 1366x768 workaround compared the screen height in physical px against that logical figure, and against `frame` rather than `visibleFrame`, so it fired at 1366x768 @100 % and was still 40 px too tall.

This PR opens the window at the screen's work area (screen minus taskbar) when that is smaller than 1088x880, DPI-corrected on Windows where `window_size` reports the work area in physical pixels.

Review points from #78 addressed here:

- `logicalWorkArea` and `desktopWindowSizeFor` are public top-level functions in `lib/desktop/desktop_window_size.dart`, tested directly (`docs/TESTING.md`: no `@visibleForTesting`). The platform decision is passed in as `workAreaIsPhysical`, so the functions have no `Platform.is*` branch and need no `testOn:` split; `start_app.dart` passes `Platform.isWindows`.
- An unusable scale factor (0, negative, NaN, infinite) now fails closed: the work area is reported as unknown and the default size is kept, instead of a physical size being passed off as logical.
- `visibleFrame` is bounded by `frame`.
- A null `getCurrentScreen()` and an unusable screen report are both logged.

No UI scaling in this PR. On a work area shorter than 880 the window is shorter than the screens were designed for; making those screens flexible is the follow-up to #78.

Tests: 8 cases covering the logical/physical conversion, the fail-closed paths, the frame bound and the per-axis clamp. `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)